### PR TITLE
remove: soft_delete_enabled field that is not required anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.0
+
+### Removed
+
+- remove the `soft_delete_enabled` field : this is now required by Azure and it can no longer be disabled.
+
 ## v0.0.2
 
 - fix access policies

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # terraform-azure-key-vault
 
-Terraform module to manage an `Azure Key Vault`.
+Terraform module to manage an [`Azure Key Vault`](https://docs.microsoft.com/en-us/azure/key-vault/).
 
-![Terraform Version](https://img.shields.io/badge/Terraform-0.12.x-green.svg) ![Terraform Version](https://img.shields.io/badge/Terraform-0.13.x-green.svg)
+![Terraform Version](https://img.shields.io/badge/Terraform-%3E=%200.12.0-green)
 
 See `variables.tf` for more information about input values.
 
 ## Usage
 
 ```hcl
-module "kv"
-  source = "github.com/scalair/terraform-azure-key-vault"
+module "kv" {
+  source = "github.com/Xat59/terraform-azure-key-vault"
 
   location              = "francecentral"
   resource_group_name   = "rg-project1-francecentral"
@@ -26,4 +26,5 @@ module "kv"
     client      = "scalair"
     terraform   = "true"
   }
+}
 ```

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,6 @@ resource "azurerm_key_vault" "kv" {
   tenant_id = var.tenant_id
 
   purge_protection_enabled   = var.purge_protection_enabled
-  soft_delete_enabled        = var.soft_delete_enabled
   soft_delete_retention_days = var.soft_delete_retention_days
 
   enabled_for_deployment          = var.enabled_for_deployment

--- a/variables.tf
+++ b/variables.tf
@@ -71,12 +71,6 @@ variable "purge_protection_enabled" {
   default     = false
 }
 
-variable "soft_delete_enabled" {
-  type        = bool
-  description = "(Optional) Should Soft Delete be enabled for this Key Vault? Defaults to false."
-  default     = false
-}
-
 variable "soft_delete_retention_days" {
   type        = number
   description = "(Optional) The number of days that items should be retained for once soft-deleted. Defaults to 7."


### PR DESCRIPTION
As of 2020-12-15 Azure now requires that Soft Delete is enabled on Key Vaults and this can no longer be disabled. Version v2.42 of the Azure Provider and later ignore the value of the soft_delete_enabled field and force this value to be true - as such this field can be safely removed from your Terraform Configuration. 